### PR TITLE
Update Zoom.json to do basic auth for the token request

### DIFF
--- a/Zoom.json
+++ b/Zoom.json
@@ -497,6 +497,7 @@
             "accept": "application/json"
         },
         "authOptions": {
+            "useBasicAuthPost": true,
             "authUrl": "https://api.zoom.us/oauth/token",
             "directToken":true,
             "JWT": {


### PR DESCRIPTION
Added usage of the new `useBasicAuthPost` option in the authentication options for token requests for oauth This should be available in the next NIM release (AFTER 3.0.1457)